### PR TITLE
Fix migration edge case

### DIFF
--- a/src/Data/retry.lua
+++ b/src/Data/retry.lua
@@ -3,13 +3,13 @@ local Promise = require(script.Parent.Parent.Parent.Promise)
 
 local function retry(attempts, delay, callback)
 	for attempt = 1, attempts do
-		local ok, value = pcall(callback)
+		local result, value = callback()
 
-		if ok then
+		if result == "succeed" then
 			return true, value
-		end
-
-		if attempt == attempts then
+		elseif result == "fail" then
+			return false, value
+		elseif attempt == attempts then
 			return false, `DataStoreFailure({value})`
 		end
 

--- a/src/Data/throttleUpdate.lua
+++ b/src/Data/throttleUpdate.lua
@@ -18,23 +18,25 @@ local function startQueue()
 					task.wait()
 				end
 
-				local success, transformed
+				local result, transformed
 
-				local data = request.dataStore:UpdateAsync(request.key, function(...)
-					success, transformed = request.transform(...)
+				local updateOk, err = pcall(function()
+					request.dataStore:UpdateAsync(request.key, function(...)
+						result, transformed = request.transform(...)
 
-					if not success then
-						return nil
-					else
-						return transformed
-					end
+						if result == "succeed" then
+							return transformed
+						else
+							return nil
+						end
+					end)
 				end)
 
-				if not success then
-					error(transformed)
+				if not updateOk then
+					return "retry", err
 				end
 
-				return data
+				return result, transformed
 			end)
 
 			if ok then

--- a/src/Document.lua
+++ b/src/Document.lua
@@ -61,7 +61,7 @@ function Document:save()
 
 	return Data.save(self.collection.dataStore, self.key, function(value)
 		if value.lockId ~= self.lockId then
-			return false, "The session lock was stolen"
+			return "fail", "The session lock was stolen"
 		end
 
 		local scheme, compressed = Compression.compress(self.data)
@@ -69,7 +69,7 @@ function Document:save()
 		value.compressionScheme = scheme
 		value.data = compressed
 
-		return true, value
+		return "succeed", value
 	end)
 end
 
@@ -94,7 +94,7 @@ function Document:close()
 
 	return Data.save(self.collection.dataStore, self.key, function(value)
 		if value.lockId ~= self.lockId then
-			return false, "The session lock was stolen"
+			return "fail", "The session lock was stolen"
 		end
 
 		local scheme, compressed = Compression.compress(self.data)
@@ -103,7 +103,7 @@ function Document:close()
 		value.data = compressed
 		value.lockId = nil
 
-		return true, value
+		return "succeed", value
 	end)
 end
 

--- a/src/init.spec.lua
+++ b/src/init.spec.lua
@@ -218,6 +218,28 @@ return function()
 		end).never.to.throw()
 	end)
 
+	it("throws when migration version is ahead of latest version", function(context)
+		local collection = Lapis.createCollection("collection", {
+			validate = function()
+				return true
+			end,
+			defaultData = "a",
+		})
+
+		local dataStore = context.dataStoreService.dataStores.collection.global
+		dataStore:write("document", {
+			compressionScheme = "None",
+			migrationVersion = 1,
+			data = "b",
+		})
+
+		local promise = collection:load("document")
+
+		expect(function()
+			promise:expect()
+		end).to.throw("Saved migration version ahead of latest version")
+	end)
+
 	it("closing and immediately opening should return a new document", function(context)
 		local collection = Lapis.createCollection("ccc", DEFAULT_OPTIONS)
 


### PR DESCRIPTION
This fixes an edge case that allowed a document to load even if its migration version was ahead of the server's last migration. This can happen when loading a document on an old server that has already been migrated on a new server.