### PR TITLE
Fix example edge case

### DIFF
--- a/example/src/server/init.server.lua
+++ b/example/src/server/init.server.lua
@@ -22,6 +22,14 @@ local documents = {}
 Players.PlayerAdded:Connect(function(player)
 	local ok, document = collection:load(`Player{player.UserId}`):await()
 
+	if player.Parent == nil then
+		if ok then
+			document:close()
+		end
+
+		return
+	end
+
 	if ok then
 		local old = document:read()
 
@@ -34,6 +42,8 @@ Players.PlayerAdded:Connect(function(player)
 		})
 
 		documents[player] = document
+	else
+		warn(`Player {player.Name}'s data failed to load`)
 	end
 end)
 


### PR DESCRIPTION
The player can leave the game before their document finishes loading. Before, the document never closed because it loaded after the `PlayerRemoving` connection fires. This checks if the player left when the document loads and closes it if they did.