### PR TITLE
Fix save merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased Changes
 * Remove write cooldown throttling since write cooldowns [were removed](https://devforum.roblox.com/t/removal-of-6s-cool-down-for-data-stores/2436230)
+* Fix save merging algorithm ([#13])
+
+[#13]: https://github.com/nezuo/lapis/pull/13
 
 ## 0.2.1 - June 10, 2023
 * Move TestEZ and DataStoreServiceMock to dev dependencies

--- a/src/AutoSave.lua
+++ b/src/AutoSave.lua
@@ -1,7 +1,5 @@
 local RunService = game:GetService("RunService")
 
-local Promise = require(script.Parent.Parent.Promise)
-
 local UPDATE_INTERVAL = 5 * 60
 
 local AutoSave = {}
@@ -41,16 +39,7 @@ function AutoSave:start()
 			self.documents[#self.documents]:close()
 		end
 
-		local promises = {}
-
-		-- This will wait for documents that closed before BindToClose was called.
-		for _, pendingSaves in self.data:getPendingSaves() do
-			for _, pendingSave in pendingSaves do
-				table.insert(promises, pendingSave.promise)
-			end
-		end
-
-		Promise.allSettled(promises):await()
+		self.data:waitForOngoingSaves():await()
 	end)
 end
 


### PR DESCRIPTION
Save merging is when you override a save that hasn't been processed yet with a new one. 
```lua
-- This could result in only a single save call since they get merged.
document:save()
document:save()
document:save()
```

This fixes an edge case where we merge saves when it's not safe. For example, if you call save and then call close while the save is running `UpdateAsync` it would result in the document never being closed because the merge doesn't take affect since the `UpdateAsync` call has already been made.

Essentially it's always safe to merge saves unless `UpdateAsync` is running.

This PR fixes this edge case by keeping track of `ongoingSaves` and `pendingSaves`. `ongoingSaves` are saves that have been added to the throttle queue. `pendingSaves` are saves that are waiting for their respective `ongoingSave` to finish. We only merge pending saves now, we do not merge pending saves with ongoing saves. This means the merge algorithm is not completely optimal since it can be safe to merge saves even if they are in the throttle queue as long as they haven't called `UpdateAsync`. I plan to use the optimal algorithm eventually. 
