### PR TITLE
Wait for documents to close in game:BindToClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Lapis Changelog
 
 ## Unreleased Changes
+* Fix `game:BindToClose` not waiting for documents to close.
 
 ## 0.2.3 - July 19, 2023
 * Fix silly mistake where I don't return the collection from `createCollection`

--- a/src/AutoSave.lua
+++ b/src/AutoSave.lua
@@ -22,6 +22,14 @@ function AutoSave:removeDocument(document)
 	table.remove(self.documents, index)
 end
 
+function AutoSave:onGameClose()
+	while #self.documents > 0 do
+		self.documents[#self.documents]:close()
+	end
+
+	self.data:waitForOngoingSaves():await()
+end
+
 function AutoSave:start()
 	local nextUpdateAt = os.clock() + UPDATE_INTERVAL
 	RunService.Heartbeat:Connect(function()
@@ -35,11 +43,7 @@ function AutoSave:start()
 	end)
 
 	game:BindToClose(function()
-		while #self.documents > 0 do
-			self.documents[#self.documents]:close()
-		end
-
-		self.data:waitForOngoingSaves():await()
+		self:onGameClose()
 	end)
 end
 

--- a/src/Data/init.lua
+++ b/src/Data/init.lua
@@ -32,14 +32,14 @@ end
 function Data:waitForOngoingSaves()
 	local promises = {}
 
-	for _, ongoingSave in self.ongoingSaves do
-		table.insert(
-			promises,
-			Promise.allSettled({
-				ongoingSave.promise,
-				if ongoingSave.pendingSave ~= nil then ongoingSave.pendingSave.promise else nil,
-			})
-		)
+	for _, ongoingSaves in self.ongoingSaves do
+		for _, ongoingSave in ongoingSaves do
+			if ongoingSave.pendingSave ~= nil then
+				table.insert(promises, ongoingSave.pendingSave.promise)
+			end
+
+			table.insert(promises, ongoingSave.promise)
+		end
 	end
 
 	return Promise.allSettled(promises)

--- a/src/Internal.lua
+++ b/src/Internal.lua
@@ -18,6 +18,10 @@ function Internal.new(enableAutoSave)
 
 	local internal = {}
 
+	if not enableAutoSave then
+		internal.autoSave = autoSave
+	end
+
 	function internal.setConfig(values)
 		config:set(values)
 	end


### PR DESCRIPTION
Fixes `game:BindToClose` not waiting for the documents to close. It collects all of the close promises in a table. The issue was that I wasn't iterating over the correct table when looking for the promises.