### PR TITLE
Convert from TestEZ to Midori

### DIFF
--- a/test/runTests.server.lua
+++ b/test/runTests.server.lua
@@ -1,9 +1,8 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
-local TestEZ = require(ReplicatedStorage.DevPackages.TestEZ)
+local Midori = require(ReplicatedStorage.DevPackages.Midori)
 
-local startedAt = os.clock()
-
-TestEZ.TestBootstrap:run({ ReplicatedStorage.Packages.Lapis })
-
-print(string.format("Tests finished running in %.3f seconds", os.clock() - startedAt))
+Midori.runTests(ReplicatedStorage.Packages.Lapis, {
+	timeoutWarningDelay = 3,
+	concurrent = true,
+})

--- a/wally.lock
+++ b/wally.lock
@@ -14,10 +14,10 @@ dependencies = []
 
 [[package]]
 name = "nezuo/lapis"
-version = "0.2.1"
-dependencies = [["Promise", "evaera/promise@4.0.0"], ["DataStoreServiceMock", "nezuo/data-store-service-mock@0.3.0"], ["TestEZ", "roblox/testez@0.4.1"]]
+version = "0.2.4"
+dependencies = [["Promise", "evaera/promise@4.0.0"], ["DataStoreServiceMock", "nezuo/data-store-service-mock@0.3.0"], ["Midori", "nezuo/midori@0.1.2"]]
 
 [[package]]
-name = "roblox/testez"
-version = "0.4.1"
+name = "nezuo/midori"
+version = "0.1.2"
 dependencies = []

--- a/wally.toml
+++ b/wally.toml
@@ -10,5 +10,5 @@ realm = "server"
 Promise = "evaera/promise@4.0.0"
 
 [dev-dependencies]
-TestEZ = "roblox/testez@0.4.1"
+Midori = "nezuo/midori@0.1.2"
 DataStoreServiceMock = "nezuo/data-store-service-mock@0.3.0"


### PR DESCRIPTION
`Midori` is a new testing library I made. It has a nicer output than TestEZ (in my opinion) and allows us to run tests concurrently. We can run tests concurrently because they aren't sharing any state. It also warns if a test is taking to long to finish to easily track down tests that infinitely yield. That was an issue I dealt with a lot. It also doesn't inject any global functions.