### PR TITLE
Fix flaky test

### DIFF
--- a/src/init.test.lua
+++ b/src/init.test.lua
@@ -120,14 +120,14 @@ return function(x)
 		otherCollection:load("doc"):expect()
 	end)
 
-	x.test("load should retry when document is session loked", function(context)
+	x.test("load should retry when document is session locked", function(context)
 		local collection = context.lapis.createCollection("collection", DEFAULT_OPTIONS)
 		local document = collection:load("doc", DEFAULT_OPTIONS):expect()
 
 		local otherLapis = Internal.new(false)
 		otherLapis.setConfig({
 			dataStoreService = context.dataStoreService,
-			loadAttempts = 2,
+			loadAttempts = 4,
 			loadRetryDelay = 0.5,
 			showRetryWarnings = false,
 		})


### PR DESCRIPTION
This test was occasionally failing because the `task.wait(0.1)` was taking over `0.5` seconds to complete. This is because `task.wait` can take longer than expected when the game is starting up. To fix the issue, I just added more load attempts.