### PR TITLE
Add beforeClose

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -33,6 +33,7 @@ export type Document<T> = {
 	write: (self: Document<T>, T) -> (),
 	save: (self: Document<T>) -> PromiseTypes.TypedPromise<()>,
 	close: (self: Document<T>) -> PromiseTypes.TypedPromise<()>,
+	beforeClose: (self: Document<T>, callback: () -> ()) -> (),
 }
 
 --[=[

--- a/wally.lock
+++ b/wally.lock
@@ -14,10 +14,10 @@ dependencies = []
 
 [[package]]
 name = "nezuo/lapis"
-version = "0.2.4"
-dependencies = [["Promise", "evaera/promise@4.0.0"], ["DataStoreServiceMock", "nezuo/data-store-service-mock@0.3.0"], ["Midori", "nezuo/midori@0.1.2"]]
+version = "0.2.5"
+dependencies = [["Promise", "evaera/promise@4.0.0"], ["DataStoreServiceMock", "nezuo/data-store-service-mock@0.3.0"], ["Midori", "nezuo/midori@0.1.3"]]
 
 [[package]]
 name = "nezuo/midori"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = []

--- a/wally.toml
+++ b/wally.toml
@@ -10,5 +10,5 @@ realm = "server"
 Promise = "evaera/promise@4.0.0"
 
 [dev-dependencies]
-Midori = "nezuo/midori@0.1.2"
+Midori = "nezuo/midori@0.1.3"
 DataStoreServiceMock = "nezuo/data-store-service-mock@0.3.0"


### PR DESCRIPTION
There are a few nuances to worry about with this. The user can call `document:close` or `document:save` inside of the callback. They can error or yield in the callback.

The behavior I decided to go with is the following:
* If the callback errors, the return promise will reject but the document will still count as closed and `document:close` cannot be called again even though the data isn't saved and the lock isn't removed.
* `document:close` and `document:save` will error if called inside of the callback.
* `document:beforeClose` will error if called more than once.