### PR TITLE
Add APIs to set the user ids for a document

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -25,12 +25,14 @@ export type CollectionOptions<T> = {
 }
 
 export type Collection<T> = {
-	load: (self: Collection<T>, key: string) -> PromiseTypes.TypedPromise<Document<T>>,
+	load: (self: Collection<T>, key: string, defaultUserIds: { number }) -> PromiseTypes.TypedPromise<Document<T>>,
 }
 
 export type Document<T> = {
 	read: (self: Document<T>) -> T,
 	write: (self: Document<T>, T) -> (),
+	addUserId: (self: Document<T>, userId: number) -> (),
+	removeUserId: (self: Document<T>, userId: number) -> (),
 	save: (self: Document<T>) -> PromiseTypes.TypedPromise<()>,
 	close: (self: Document<T>) -> PromiseTypes.TypedPromise<()>,
 	beforeClose: (self: Document<T>, callback: () -> ()) -> (),

--- a/src/init.lua
+++ b/src/init.lua
@@ -25,7 +25,7 @@ export type CollectionOptions<T> = {
 }
 
 export type Collection<T> = {
-	load: (self: Collection<T>, key: string, defaultUserIds: { number }) -> PromiseTypes.TypedPromise<Document<T>>,
+	load: (self: Collection<T>, key: string, defaultUserIds: { number }?) -> PromiseTypes.TypedPromise<Document<T>>,
 }
 
 export type Document<T> = {

--- a/wally.lock
+++ b/wally.lock
@@ -9,13 +9,13 @@ dependencies = []
 
 [[package]]
 name = "nezuo/data-store-service-mock"
-version = "0.3.0"
+version = "0.3.5"
 dependencies = []
 
 [[package]]
 name = "nezuo/lapis"
 version = "0.2.5"
-dependencies = [["Promise", "evaera/promise@4.0.0"], ["DataStoreServiceMock", "nezuo/data-store-service-mock@0.3.0"], ["Midori", "nezuo/midori@0.1.3"]]
+dependencies = [["Promise", "evaera/promise@4.0.0"], ["DataStoreServiceMock", "nezuo/data-store-service-mock@0.3.5"], ["Midori", "nezuo/midori@0.1.3"]]
 
 [[package]]
 name = "nezuo/midori"

--- a/wally.toml
+++ b/wally.toml
@@ -11,4 +11,4 @@ Promise = "evaera/promise@4.0.0"
 
 [dev-dependencies]
 Midori = "nezuo/midori@0.1.3"
-DataStoreServiceMock = "nezuo/data-store-service-mock@0.3.0"
+DataStoreServiceMock = "nezuo/data-store-service-mock@0.3.5"


### PR DESCRIPTION
### Changes
* Changed `Collection:load(key: string)` to `Collection:load(key: string, defaultUserIds: {number}?)`
  * `defaultUserIds` only apply if it's the first time the document has ever been loaded.
* Added `Document:addUserId(userId: number)`
* Added `Document:removeUserId(userId: number)`

Closes #21 