### PR TITLE
Don't load when data is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased Changes
 * Removed internal compression code since compression is no longer planned ([#31])
+* Data is no longer loaded if it doesn't pass the `validate` function. This means it won't be session locked and migrated. ([#32])
 
 [#31]: https://github.com/nezuo/lapis/pull/31
+[#32]: https://github.com/nezuo/lapis/pull/32
 
 ## 0.2.7 - November 12, 2023
 * Add `Document:beforeSave` callback to make changes to a document before it saves ([#29])

--- a/src/Collection.lua
+++ b/src/Collection.lua
@@ -70,6 +70,12 @@ function Collection:load(key, defaultUserIds)
 				end
 
 				local migrated = Migration.migrate(self.options.migrations, value.migrationVersion, value.data)
+
+				local ok, message = self.options.validate(migrated)
+				if not ok then
+					return "fail", `Invalid data: {message}`
+				end
+
 				local data = {
 					migrationVersion = #self.options.migrations,
 					lockId = lockId,
@@ -80,11 +86,6 @@ function Collection:load(key, defaultUserIds)
 			end)
 			:andThen(function(value, keyInfo)
 				local data = value.data
-
-				local ok, message = self.options.validate(data)
-				if not ok then
-					return Promise.reject(message)
-				end
 
 				freezeDeep(data)
 

--- a/src/init.test.lua
+++ b/src/init.test.lua
@@ -14,6 +14,7 @@ local DEFAULT_OPTIONS = {
 }
 
 return function(x)
+	local assertEqual = x.assertEqual
 	local shouldThrow = x.shouldThrow
 
 	x.beforeEach(function(context)
@@ -99,14 +100,18 @@ return function(x)
 		end, "data is invalid")
 	end)
 
-	x.test("throws when loading invalid data", function(context)
-		local collection = context.lapis.createCollection("apples", DEFAULT_OPTIONS)
+	x.test("should not override data if validation fails", function(context)
+		local collection = context.lapis.createCollection("collection", DEFAULT_OPTIONS)
 
-		context.write("apples", "a", { apples = "string" })
+		context.write("collection", "doc", { apples = "string" })
+
+		local old = context.read("collection", "doc")
 
 		shouldThrow(function()
-			collection:load("a"):expect()
+			collection:load("doc"):expect()
 		end, "apples should be a number")
+
+		assertEqual(old, context.read("collection", "doc"))
 	end)
 
 	x.test("should session lock the document", function(context)


### PR DESCRIPTION
Previously, data would be validated after load (it would be session locked and migrated). Now, the data will fail to load if it is invalid.

Fixes #30.

