### PR TITLE
Don't error when calling close again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Lapis Changelog
 
 ## Unreleased Changes
-* `Document:close` no longer errors when called again. ([#35])
+* `Document:close` no longer errors when called again and instead returns the original promise. ([#35])
   * This is so it won't error when called from `PlayerRemoving` if `game:BindToClose` happens to run first.
 
 [#35]: https://github.com/nezuo/lapis/pull/35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Lapis Changelog
 
 ## Unreleased Changes
+* `Document:close` no longer errors when called again. ([#35])
+  * This is so it won't error when called from `PlayerRemoving` if `game:BindToClose` happens to run first.
+
+[#35]: https://github.com/nezuo/lapis/pull/35
 
 ## 0.2.8 - December 27, 2023
 * Removed internal compression code since compression is no longer planned ([#31])

--- a/src/Document.test.lua
+++ b/src/Document.test.lua
@@ -101,7 +101,7 @@ return function(x)
 		end, "foo must be a string")
 	end)
 
-	x.test("throws when writing/saving/closing a closed document", function(context)
+	x.test("methods throw when called on a closed document", function(context)
 		local document = context.lapis.createCollection("5", DEFAULT_OPTIONS):load("doc"):expect()
 
 		local promise = document:close()
@@ -115,10 +115,22 @@ return function(x)
 		end, "Cannot save a closed document")
 
 		shouldThrow(function()
-			document:close()
-		end, "Cannot close a closed document")
+			document:addUserId(1234)
+		end, "Cannot add user id to a closed document")
+
+		shouldThrow(function()
+			document:removeUserId(1234)
+		end, "Cannot remove user id from a closed document")
 
 		promise:expect()
+	end)
+
+	x.test("close returns first promise when called again", function(context)
+		local document = context.lapis.createCollection("col", DEFAULT_OPTIONS):load("doc"):expect()
+
+		local promise = document:close()
+
+		assertEqual(promise, document:close())
 	end)
 
 	x.test("loads with default data", function(context)

--- a/src/init.test.lua
+++ b/src/init.test.lua
@@ -268,8 +268,8 @@ return function(x)
 		-- Verify each document has been closed.
 		for _, document in { one, two, three } do
 			shouldThrow(function()
-				document:close():expect()
-			end, "Cannot close a closed document")
+				document:save():expect()
+			end, "Cannot save a closed document")
 		end
 
 		context.dataStoreService.yield:stopYield()


### PR DESCRIPTION
Instead of throwing an error when calling `Document:close()` again, it will instead return the original promise from the first call.

The motivation for this change is so that it won't error when calling it from `PlayerRemoving` if `game:BindToClose` happens to run first.