### PR TITLE
Fix loading during game:BindToClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Lapis Changelog
 
 ## Unreleased Changes
-* Documents loaded after `game:BindToClose` no longer load. If a document loads because UpdateAsync is called just before game close, it is automatically closed. ([#43])
+* `Document:load` now infinitely yields and doesn't load the document after `game:BindToClose` is called. If a document
+does load because UpdateAsync is called just before game close, it is automatically closed. ([#43])
 
 [#43]: https://github.com/nezuo/lapis/pull/43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Lapis Changelog
 
 ## Unreleased Changes
+* Documents loaded after `game:BindToClose` no longer load. If a document loads because UpdateAsync is called just before game close, it is automatically closed. ([#43])
+
+[#43]: https://github.com/nezuo/lapis/pull/43
 
 ## 0.2.9 - January 1, 2024
 * `Document:close` no longer errors when called again and instead returns the original promise. ([#35])

--- a/src/Data/init.lua
+++ b/src/Data/init.lua
@@ -50,7 +50,7 @@ function Data:load(dataStore, key, transform)
 		local attempts = self.config:get("loadAttempts")
 		local retryDelay = self.config:get("loadRetryDelay")
 
-		return self.throttle:updateAsync(dataStore, key, transform, attempts, retryDelay)
+		return self.throttle:updateAsync(dataStore, key, transform, true, attempts, retryDelay)
 	end)
 end
 
@@ -65,7 +65,7 @@ function Data:save(dataStore, key, transform)
 		local attempts = self.config:get("saveAttempts")
 		local promise = self
 			.throttle
-			:updateAsync(dataStore, key, transform, attempts)
+			:updateAsync(dataStore, key, transform, false, attempts)
 			:andThenReturn() -- Save promise should not resolve with a value.
 			:finally(function()
 				self.ongoingSaves[dataStore][key] = nil

--- a/src/Internal.lua
+++ b/src/Internal.lua
@@ -19,6 +19,7 @@ function Internal.new(enableAutoSave)
 	local internal = {}
 
 	if not enableAutoSave then
+		-- This exposes AutoSave to unit tests.
 		internal.autoSave = autoSave
 	end
 

--- a/wally.lock
+++ b/wally.lock
@@ -14,7 +14,7 @@ dependencies = []
 
 [[package]]
 name = "nezuo/lapis"
-version = "0.2.5"
+version = "0.2.9"
 dependencies = [["Promise", "evaera/promise@4.0.0"], ["DataStoreServiceMock", "nezuo/data-store-service-mock@0.3.5"], ["Midori", "nezuo/midori@0.1.3"]]
 
 [[package]]


### PR DESCRIPTION
This PR stops documents from loading after `game:BindToClose` has been called. If the `UpdateAsync` call has been made, we can only stop it by returning `nil`, we can't stop the request once a value has been sent. This will also automatically close documents that still manage to load after `game:BindToClose`.

Resolves #37.