### PR TITLE
Remove load promise caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Lapis Changelog
 
 ## Unreleased Changes
+* **BREAKING CHANGE**: `Collection:load` no longer caches promises. Each call will now return a unique promise and attempt to load the document separately. This is to fix an edge case that can result in data loss. More information can be found in the pull request. ([#48])
+
+[#48]: https://github.com/nezuo/lapis/pull/48
 
 ## 0.2.11 - April 9, 2024
 * Fix infinite yield in `game:BindToClose` caused by a document failing to load. ([#45])

--- a/src/Collection.lua
+++ b/src/Collection.lua
@@ -25,7 +25,6 @@ function Collection.new(name, options, data, autoSave, config)
 	return setmetatable({
 		dataStore = config:get("dataStoreService"):GetDataStore(name),
 		options = options,
-		openDocuments = {},
 		data = data,
 		autoSave = autoSave,
 	}, Collection)
@@ -47,85 +46,80 @@ function Collection:load(key, defaultUserIds)
 		return Promise.new(function() end)
 	end
 
-	if self.openDocuments[key] == nil then
-		local lockId = HttpService:GenerateGUID(false)
+	local lockId = HttpService:GenerateGUID(false)
 
-		self.autoSave.ongoingLoads += 1
+	self.autoSave.ongoingLoads += 1
 
-		self.openDocuments[key] = self
-			.data
-			:load(self.dataStore, key, function(value, keyInfo)
-				if value == nil then
-					local data = {
-						migrationVersion = #self.options.migrations,
-						lockId = lockId,
-						data = self.options.defaultData,
-					}
-
-					return "succeed", data, defaultUserIds
-				end
-
-				if value.migrationVersion > #self.options.migrations then
-					return "fail", "Saved migration version ahead of latest version"
-				end
-
-				if
-					value.lockId ~= nil
-					and (DateTime.now().UnixTimestampMillis - keyInfo.UpdatedTime) / 1000 < LOCK_EXPIRE
-				then
-					return "retry", "Could not acquire lock"
-				end
-
-				local migrated = Migration.migrate(self.options.migrations, value.migrationVersion, value.data)
-
-				local ok, message = self.options.validate(migrated)
-				if not ok then
-					return "fail", `Invalid data: {message}`
-				end
-
+	return self
+		.data
+		:load(self.dataStore, key, function(value, keyInfo)
+			if value == nil then
 				local data = {
 					migrationVersion = #self.options.migrations,
 					lockId = lockId,
-					data = migrated,
+					data = self.options.defaultData,
 				}
 
-				return "succeed", data, keyInfo:GetUserIds(), keyInfo:GetMetadata()
-			end)
-			:andThen(function(value, keyInfo)
-				if value == "cancelled" then
-					self.autoSave.ongoingLoads -= 1
+				return "succeed", data, defaultUserIds
+			end
 
-					-- Infinitely yield because the load was cancelled by game:BindToClose.
-					return Promise.new(function() end)
-				end
+			if value.migrationVersion > #self.options.migrations then
+				return "fail", "Saved migration version ahead of latest version"
+			end
 
-				local data = value.data
+			if
+				value.lockId ~= nil
+				and (DateTime.now().UnixTimestampMillis - keyInfo.UpdatedTime) / 1000 < LOCK_EXPIRE
+			then
+				return "retry", "Could not acquire lock"
+			end
 
-				freezeDeep(data)
+			local migrated = Migration.migrate(self.options.migrations, value.migrationVersion, value.data)
 
-				local document = Document.new(self, key, self.options.validate, lockId, data, keyInfo:GetUserIds())
+			local ok, message = self.options.validate(migrated)
+			if not ok then
+				return "fail", `Invalid data: {message}`
+			end
 
-				self.autoSave:finishLoad(document)
+			local data = {
+				migrationVersion = #self.options.migrations,
+				lockId = lockId,
+				data = migrated,
+			}
 
-				if self.autoSave.gameClosed then
-					-- Infinitely yield because the document will automatically be closed.
-					return Promise.new(function() end)
-				end
+			return "succeed", data, keyInfo:GetUserIds(), keyInfo:GetMetadata()
+		end)
+		:andThen(function(value, keyInfo)
+			if value == "cancelled" then
+				self.autoSave.ongoingLoads -= 1
 
-				self.autoSave:addDocument(document)
+				-- Infinitely yield because the load was cancelled by game:BindToClose.
+				return Promise.new(function() end)
+			end
 
-				return document
-			end)
-			-- finally is used instead of catch so it doesn't handle rejection.
-			:finally(function(status)
-				if status ~= Promise.Status.Resolved then
-					self.openDocuments[key] = nil
-					self.autoSave.ongoingLoads -= 1
-				end
-			end)
-	end
+			local data = value.data
 
-	return self.openDocuments[key]
+			freezeDeep(data)
+
+			local document = Document.new(self, key, self.options.validate, lockId, data, keyInfo:GetUserIds())
+
+			self.autoSave:finishLoad(document)
+
+			if self.autoSave.gameClosed then
+				-- Infinitely yield because the document will automatically be closed.
+				return Promise.new(function() end)
+			end
+
+			self.autoSave:addDocument(document)
+
+			return document
+		end)
+		-- finally is used instead of catch so it doesn't handle rejection.
+		:finally(function(status)
+			if status ~= Promise.Status.Resolved then
+				self.autoSave.ongoingLoads -= 1
+			end
+		end)
 end
 
 return Collection

--- a/src/Document.lua
+++ b/src/Document.lua
@@ -149,8 +149,6 @@ function Document:close()
 			:finally(function()
 				self.closed = true
 
-				self.collection.openDocuments[self.key] = nil
-
 				self.collection.autoSave:removeDocument(self)
 			end)
 			:andThen(function()

--- a/src/init.test.lua
+++ b/src/init.test.lua
@@ -172,17 +172,19 @@ return function(x)
 		promise:expect()
 	end)
 
-	x.test("load returns same promise/document", function(context)
-		local collection = context.lapis.createCollection("def", DEFAULT_OPTIONS)
+	x.test("second load should fail because of session lock", function(context)
+		local collection = context.lapis.createCollection("collection", DEFAULT_OPTIONS)
 
-		local promise1 = collection:load("def")
-		local promise2 = collection:load("def")
+		context.lapis.setConfig({ loadAttempts = 1 })
 
-		assert(promise1 == promise2, "load returns different promises")
+		local first = collection:load("document")
+		local second = collection:load("document")
 
-		Promise.all({ promise1, promise2 }):expect()
+		first:expect()
 
-		assert(promise1:expect() == promise2:expect(), "promise resolved with different values")
+		shouldThrow(function()
+			second:expect()
+		end, "Could not acquire lock")
 	end)
 
 	x.test("load returns a new promise when first load fails", function(context)


### PR DESCRIPTION
### The Issue
The `Example Usage` page in the docs contains an edge that can result in data loss. Here's an explanation of the edge case:

`Collection:load` caches load promises for each document. The promise is removed from the cache when `Document:close` is called.

1. Player joins the server and `Document:load` is called which returns a promise that is cached.
2. Player leaves and rejoins that same server.
3. `Document:load` is called again, the promise from the first load never finished (meaning `Document:close` hasn't been called yet), so the cached promise from the first load is returned.
4. The promise resolves, the original load calls `Document:close` because that `Player` instance is no longer in the game.
5. The new load now has a closed document and none of their data will be saved at this point.

This edge case probably has not happened in practice because it would require a player rejoining the same server before their document loads. Nonetheless, it should absolutely be fixed. It could be fixed by modifying the example but I think changing Lapis makes more sense.

### The Fix
Lapis no longer caches load promises. This is a breaking change, though I don't know if anyone relies on this behavior.