### PR TITLE
Backwards compatible migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@
 * Migrations can now update the data mutably. Note: The value still needs to be returned from the migration function. ([#51])
 * Gracefully handle `validate` throwing an error in `Collection:load`. Before it would keep retrying the load and spam the console with confusing errors. ([#52])
 * Allow `defaultData` to be a function. The return value will be validated when a new document is created. ([#53])
+* Migrations can now be marked as `backwardsCompatible`. This allows documents to be loaded on servers with an older version as long as they are compatible.
+For more information, see the [docs](https://nezuo.github.io/lapis/docs/Migrations#backwards-compatibility). ([#54])
 
 [#50]: https://github.com/nezuo/lapis/pull/50
 [#51]: https://github.com/nezuo/lapis/pull/51
 [#52]: https://github.com/nezuo/lapis/pull/52
 [#53]: https://github.com/nezuo/lapis/pull/53
+[#54]: https://github.com/nezuo/lapis/pull/54
 
 ### 0.3.0 - April 14, 2024
 * **BREAKING CHANGE**: `Collection:load` no longer caches promises. Each call will now return a unique promise and attempt to load the document separately. This is to fix an edge case that can result in data loss. More information can be found in the pull request. ([#48])

--- a/docs/Migrations.md
+++ b/docs/Migrations.md
@@ -2,21 +2,24 @@
 sidebar_position: 3
 ---
 
-# Writing Migrations
+# Migrations
+
+## Writing Migrations
 Migrations allow you to update the structure of your data over time. You can add new keys, remove ones you no longer need, or change the way you store something.
 
 Here is an example of a few migrations:
 ```lua
 local MIGRATIONS = {
-    -- Migrate from version 1 to 2.
+    -- Migrate from version 0 to 1.
     function(old)
         return Dictionary.merge(old, {
             coins = 0, -- Add a key called coins to the data.
         })
     end,
-    -- Migrate from version 2 to 3.
+    -- Migrate from version 1 to 2.
     function(old)
-        -- We no longer need the playTime key, so we remove it. Note: Migrations can update the data mutably but you still need to return the value.
+        -- We no longer need the playTime key, so we remove it.
+        -- Note: Migrations can update the data mutably but you still need to return the value.
         old.playTime = nil
 
         return old
@@ -29,3 +32,56 @@ local collection = Lapis.createCollection("collection", {
     defaultData = DEFAULT_DATA,
 })
 ```
+
+## Backwards Compatibility
+If you release an update that includes a migration, a player might join a new server, leave, and then join an old server.
+This would cause the player's document to fail to load on the old server since the document's version would be ahead of the old server's version.
+
+To solve this problem, you have two options:
+1. Use Roblox's `Migrate To Latest Update` feature to ensure all servers are up-to-date.
+2. Make your migrations backwards compatible.
+
+Here's an example of how to make migrations backwards compatible:
+```lua
+local function v1()
+    -- v1 removes a key which causes an error on servers with version 0.
+    old.playTime = nil
+    return old
+end
+
+local function v2()
+    -- v2 adds a new value to the player's data which won't result in an error on servers with version 1.
+    old.items = {}
+    return old
+end
+
+local function v3()
+    -- v3 removes a key which causes an error on servers with version 0, 1, or 2.
+    old.coins = nil
+    return old
+end
+
+local MIGRATIONS = {
+    {
+        migrate = v1,
+        backwardsCompatible = false, -- Version 1 isn't backwards compatible with version 0.
+    },
+    {
+        migrate = v2,
+        backwardsCompatible = true, -- Version 2 is backwards compatible with version 1.
+    },
+    v3, -- Migrations aren't backwards compatible by default.
+}
+```
+
+A migration is backwards compatible with the previous version if it can be safely loaded on an old server without resulting in bugs, errors, or incorrect behavior.
+
+Generally, additive changes are backwards compatible, while removals are not. It's up to you to determine when a change is backwards compatible.
+
+Backward compatibility is transitive, so for example, if `v2` is backwards compatible with `v1` and `v3` is backwards compatible with `v2`, `v3` is also backwards compatible with `v1`.
+
+Note that a migration won't be backwards compatible if it fails to pass the previous version's validation. If you intend to
+use backwards compatibilty, you should use functions like `t.interface` over `t.strictInterface`.
+
+### How to fix mistakes in backwards compatibilty?
+If you mistakenly mark a change as backwards compatible when it isn't, you will need to use `Migrate To Latest Update` to correct it. Therefore, be careful not to mark `backwardsCompatible` incorrectly!

--- a/src/Migration.lua
+++ b/src/Migration.lua
@@ -1,9 +1,29 @@
 local Migration = {}
 
-function Migration.migrate(migrations, oldVersion, data)
-	if oldVersion < #migrations then
-		for version = oldVersion + 1, #migrations do
-			local ok, migrated = pcall(migrations[version], data)
+function Migration.getLastCompatibleVersion(migrations)
+	local serverVersion = #migrations
+
+	for version = serverVersion, 1, -1 do
+		local migration = migrations[version]
+
+		if migration.backwardsCompatible ~= true then
+			return version
+		end
+	end
+
+	return 0
+end
+
+function Migration.migrate(migrations, value)
+	local serverVersion = #migrations
+	local savedVersion = value.migrationVersion
+
+	local data = value.data
+	local lastCompatibleVersion = value.lastCompatibleVersion
+
+	if serverVersion > savedVersion then
+		for version = savedVersion + 1, #migrations do
+			local ok, migrated = pcall(migrations[version].migrate, data)
 			if not ok then
 				return false, `Migration {version} threw an error: {migrated}`
 			end
@@ -14,9 +34,17 @@ function Migration.migrate(migrations, oldVersion, data)
 
 			data = migrated
 		end
+
+		lastCompatibleVersion = Migration.getLastCompatibleVersion(migrations)
+	elseif serverVersion < savedVersion then
+		-- lastCompatibleVersion will be nil for documents that existed before backwards compatibilty was added and haven't been migrated to a new version since.
+		if lastCompatibleVersion == nil or serverVersion < lastCompatibleVersion then
+			return false,
+				`Saved migration version {savedVersion} is not backwards compatible with version {serverVersion}`
+		end
 	end
 
-	return true, data
+	return true, data, lastCompatibleVersion
 end
 
 return Migration

--- a/src/init.lua
+++ b/src/init.lua
@@ -92,7 +92,7 @@ end
 	@within Lapis
 	.validate (any) -> true | (false, string) -- Takes a document's data and returns true on success or false and an error on fail.
 	.defaultData T | (key: string) -> T -- If set to a function, it's called when a new document is created and is passed the key of the document.
-	.migrations { Migration }? -- Migrations take old data and return new data. Order is first to last.
+	.migrations { Migration }? -- Migrations take old data and return new data. Order is first to last. For more information, see: [Migrations](../docs/Migrations).
 ]=]
 
 --[=[

--- a/src/init.lua
+++ b/src/init.lua
@@ -3,6 +3,9 @@ local PromiseTypes = require(script.PromiseTypes)
 
 local internal = Internal.new(true)
 
+type Migrate = (any) -> any
+type Migration = Migrate | { backwardsCompatible: boolean?, migrate: Migrate }
+
 export type DataStoreService = {
 	GetDataStore: (name: string) -> GlobalDataStore,
 	GetRequestBudgetForRequestType: (requestType: Enum.DataStoreRequestType) -> number,
@@ -19,7 +22,7 @@ export type PartialLapisConfig = {
 
 export type CollectionOptions<T> = {
 	defaultData: T,
-	migrations: { (any) -> any }?,
+	migrations: { Migration }?,
 	validate: (T) -> (boolean, string?),
 	[any]: nil,
 }
@@ -55,6 +58,11 @@ local Lapis = {}
 ]=]
 
 --[=[
+	@type Migration (any) -> any | { backwardsCompatible: boolean?, migrate: (any) -> any }
+	@within Lapis
+]=]
+
+--[=[
 	```lua
 	Lapis.setConfig({
 		saveAttempts = 10,
@@ -84,7 +92,7 @@ end
 	@within Lapis
 	.validate (any) -> true | (false, string) -- Takes a document's data and returns true on success or false and an error on fail.
 	.defaultData any
-	.migrations { (any) -> any }? -- Migrations take old data and return new data. Order is first to last.
+	.migrations { Migration }? -- Migrations take old data and return new data. Order is first to last.
 ]=]
 
 --[=[


### PR DESCRIPTION
Migrations can now be marked as backwards compatible. Backwards compatibility is transitive, for example, if `v2` is backwards compatible with `v1` and `v3` is backwards compatible with `v2`, `v3` is also backwards compatible with `v1`.

When a document is loaded with a `migrationVersion` greater than the latest migration version the server has, the document will be loaded as long as it is backwards compatible with the server version.

A `lastCompatibleVersion` is saved to a document when it's created or when it's migrated to a new version. If `lastCompatibleVersion` is `nil` because the document existed before this feature was added and hasn't had a migration since, Lapis will assume that the document isn't backwards compatible with any version.

If a migration's `backwardsCompatible` value is changed after the fact, it won't affect documents until and unless the documents are created for the first time or they are migrated to a new version.

I chose this behavior because if you joined a server with the old `backwardsCompatible` value after joining a server with the new one, it would recalculate `lastCompatibleVersion` to be an incorrect version.

The alternative that was ruled out was recalculating `lastCompatibleVersion` every time a document was loaded.