### PR TITLE
Fix saved version being reset to latest migration version on server when saved version is ahead and backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased Changes
 * Added `Collection:read` to view a document's data without editing or session locking it. ([#59])
+* **IMPORTANT**: Fixed bug that resets a saved migration version that is ahead of the server's version and is backwards compatible. ([#60])
 
 [#59]: https://github.com/nezuo/lapis/pull/59
+[#60]: https://github.com/nezuo/lapis/pull/60
 
 ## 0.3.1 - July 6, 2024
 * Added `Document:keyInfo()`. It returns the last updated `DataStoreKeyInfo` returned from loading, saving, or closing the document. ([#50])

--- a/src/Collection.lua
+++ b/src/Collection.lua
@@ -110,6 +110,8 @@ function Collection:load(key, defaultUserIds)
 				return "retry", "Could not acquire lock"
 			end
 
+			local savedVersion = value.migrationVersion
+
 			local migrationOk, migrated, lastCompatibleVersion = Migration.migrate(self.options.migrations, value)
 			if not migrationOk then
 				return "fail", migrated
@@ -125,7 +127,7 @@ function Collection:load(key, defaultUserIds)
 			end
 
 			local data = {
-				migrationVersion = #self.options.migrations,
+				migrationVersion = math.max(savedVersion, #self.options.migrations),
 				lastCompatibleVersion = lastCompatibleVersion,
 				lockId = lockId,
 				data = migrated,

--- a/src/init.test.lua
+++ b/src/init.test.lua
@@ -550,6 +550,31 @@ return function(x)
 				-- This shouldn't error because v3 is backwards compatible with v1.
 				collectionWithV1:load("document"):expect()
 			end)
+
+			x.test("keeps saved version", function(context)
+				local collection = context.lapis.createCollection("collection", {
+					defaultData = "a",
+				})
+
+				local dataStore = context.dataStoreService.dataStores.collection.global
+				dataStore:write("document", {
+					lastCompatibleVersion = 0,
+					migrationVersion = 1,
+					data = "b",
+				})
+
+				local document = collection:load("document"):expect()
+
+				assertEqual(context.read("collection", "document").migrationVersion, 1)
+
+				document:save("document"):expect()
+
+				assertEqual(context.read("collection", "document").migrationVersion, 1)
+
+				document:close("document"):expect()
+
+				assertEqual(context.read("collection", "document").migrationVersion, 1)
+			end)
 		end)
 	end)
 


### PR DESCRIPTION
Example:
Saved version = 2
Server version = 1

When this document is loaded, it's version resets to the server version even though it keeps its migrated data.