### PR TITLE
Switch to shared wally realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Lapis Changelog
 
 ## Unreleased Changes
+* Switched wally realm to `shared`. This means Lapis can be used as a shared or server dependency. ([#62])
+
+[#62]: https://github.com/nezuo/lapis/pull/62
 
 ## 0.3.2 - August 6, 2024
 * Added `Collection:read` to view a document's data without editing or session locking it. ([#59])

--- a/wally.toml
+++ b/wally.toml
@@ -4,7 +4,7 @@ version = "0.3.2"
 registry = "https://github.com/UpliftGames/wally-index"
 exclude = ["**"]
 include = ["src", "src/*", "default.project.json", "wally.toml", "LICENSE"]
-realm = "server"
+realm = "shared"
 
 [dependencies]
 Promise = "evaera/promise@4.0.0"


### PR DESCRIPTION
This is a backwards compatible change because shared packages can still be used under `[server-dependencies]`. Lapis is open-source and doesn't need to be hidden from players. The motivation for this change is that there have been a few developers (that I know of) that didn't know about wally server dependencies and couldn't install Lapis.