### PR TITLE
Throw error if beforeSave or beforeClose yield

### DIFF
--- a/src/Document.luau
+++ b/src/Document.luau
@@ -1,5 +1,6 @@
 local freezeDeep = require(script.Parent.freezeDeep)
 local Promise = require(script.Parent.Parent.Promise)
+local noYield = require(script.Parent.noYield)
 
 local function runCallback(document, name, callback)
 	if callback == nil then
@@ -9,7 +10,7 @@ local function runCallback(document, name, callback)
 	document.callingCallback = name
 
 	return Promise.new(function(resolve, reject)
-		local ok, message = pcall(callback)
+		local ok, message = pcall(noYield, callback)
 
 		document.callingCallback = nil
 
@@ -123,7 +124,7 @@ end
 	:::
 
 	:::warning
-	If the beforeSave callback errors, the returned promise will reject and the data will not be saved.
+	If the beforeSave callback yields or errors, the returned promise will reject and the data will not be saved.
 	:::
 
 	@return Promise<()>
@@ -165,7 +166,7 @@ end
 	If called again, it will return the promise from the original call.
 
 	:::warning
-	If the beforeSave or beforeClose callbacks error, the returned promise will reject and the data will not be saved.
+	If the beforeSave or beforeClose callbacks yield or error, the returned promise will reject and the data will not be saved.
 	:::
 
 	@return Promise<()>

--- a/src/Document.test.luau
+++ b/src/Document.test.luau
@@ -238,6 +238,18 @@ return function(x)
 	end)
 
 	x.nested("Document:beforeSave", function()
+		x.test("throws when yielding", function(context)
+			local document = context.lapis.createCollection("collection", defaultOptions()):load("document"):expect()
+
+			document:beforeSave(function()
+				task.wait()
+			end)
+
+			shouldThrow(function()
+				document:save():expect()
+			end, "beforeSave callback threw error: thread is not yieldable")
+		end)
+
 		x.test("throws when setting twice", function(context)
 			local document = context.lapis.createCollection("collection", defaultOptions()):load("document"):expect()
 
@@ -299,6 +311,18 @@ return function(x)
 	end)
 
 	x.nested("Document:beforeClose", function()
+		x.test("throws when yielding", function(context)
+			local document = context.lapis.createCollection("collection", defaultOptions()):load("document"):expect()
+
+			document:beforeClose(function()
+				task.wait()
+			end)
+
+			shouldThrow(function()
+				document:close():expect()
+			end, "beforeClose callback threw error: thread is not yieldable")
+		end)
+
 		x.test("throws when setting twice", function(context)
 			local document = context.lapis.createCollection("collection", defaultOptions()):load("document"):expect()
 

--- a/src/noYield.luau
+++ b/src/noYield.luau
@@ -1,0 +1,11 @@
+local function noYield(callback)
+	for _ in
+		function()
+			callback()
+		end
+	do
+		break
+	end
+end
+
+return noYield


### PR DESCRIPTION
This fixes an edge case where one of the callbacks could yield right before or during `game:BindToClose` which means the save won't have started and `AutoSave` won't wait for the document to close.

This could be fixed without restricting yielding but there is another awkward API issue this fixes: For example, if `beforeSave` yields and `:close` is called during the yield, the close will throw an error since `:close` can't be called during the `beforeSave` callback. This could also technically be fixed by checking the `coroutine.status` of the `beforeSave` thread before throwing this error. However, if the `:close` didn't yield in its callbacks the `close` request would happen before the `save` and that would result in a save happening after the close which is not good.

We may find solutions to these edge cases but I feel that it's more correct to not allow yielding.