### PR TITLE
Remove lock from document if `Document:close` fails in specific ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@
 * Switched wally realm to `shared`. This means Lapis can be used as a shared or server dependency. ([#62])
 * `beforeClose` and `beforeSave` now throw an error if they yield. For more information, see the PR. ([#64])
 * Added `Collection:remove` to remove the data from a document. ([#65])
+* Session locks will now be removed from documents if `Document:close` fails for the following reasons: ([#66])
+  * `beforeSave`/`beforeClose` threw an error.
+  * `validate` threw an error.
+  * `validate` didn't return `true`.
 
 [#61]: https://github.com/nezuo/lapis/pull/61
 [#62]: https://github.com/nezuo/lapis/pull/62
 [#64]: https://github.com/nezuo/lapis/pull/64
 [#65]: https://github.com/nezuo/lapis/pull/65
+[#66]: https://github.com/nezuo/lapis/pull/66
 
 ## 0.3.2 - August 6, 2024
 * Added `Collection:read` to view a document's data without editing or session locking it. ([#59])

--- a/src/AutoSave.luau
+++ b/src/AutoSave.luau
@@ -13,6 +13,7 @@ function AutoSave.new(data)
 		data = data,
 		gameClosed = false,
 		ongoingLoads = 0,
+		ongoingRemoveLocks = 0,
 	}, AutoSave)
 end
 
@@ -42,16 +43,22 @@ function AutoSave:onGameClose()
 		self.documents[#self.documents]:close()
 	end
 
-	Promise.allSettled({
-		Promise.try(function()
-			while self.ongoingLoads > 0 do
-				task.wait()
-			end
-		end):andThen(function()
-			return self.data:waitForOngoingSaves()
-		end),
-		self.data:waitForOngoingSaves(),
-	}):await()
+	Promise.try(function()
+		while self.ongoingLoads > 0 do
+			task.wait()
+		end
+	end)
+		:andThen(function()
+			return Promise.allSettled({
+				self.data:waitForOngoingSaves(),
+				Promise.try(function()
+					while self.ongoingRemoveLocks > 0 do
+						task.wait()
+					end
+				end),
+			})
+		end)
+		:await()
 end
 
 function AutoSave:start()

--- a/src/Collection.luau
+++ b/src/Collection.luau
@@ -1,6 +1,7 @@
 local HttpService = game:GetService("HttpService")
 
 local Document = require(script.Parent.Document)
+local Error = require(script.Parent.Error)
 local freezeDeep = require(script.Parent.freezeDeep)
 local Migration = require(script.Parent.Migration)
 local Promise = require(script.Parent.Parent.Promise)
@@ -65,23 +66,23 @@ function Collection:load(key, defaultUserIds)
 
 	self.autoSave.ongoingLoads += 1
 
-	return self
-		.data
+	return self.data
 		:load(self.dataStore, key, function(value, keyInfo)
 			if value == nil then
 				local defaultData
 				if typeof(self.options.defaultData) == "function" then
 					local defaultOk, tailoredDefaultData = pcall(self.options.defaultData, key)
 					if not defaultOk then
-						return "fail", `'defaultData' threw an error: {tailoredDefaultData}`
+						return "fail",
+							Error.new("DefaultDataThrew", `'defaultData' threw an error: {tailoredDefaultData}`)
 					end
 
 					if self.options.validate ~= nil then
 						local validateOk, valid, message = pcall(self.options.validate, tailoredDefaultData)
 						if not validateOk then
-							return "fail", `'validate' threw an error: {valid}`
+							return "fail", Error.new("ValidateThrew", `'validate' threw an error: {valid}`)
 						elseif not valid then
-							return "fail", `Invalid data: {message}`
+							return "fail", Error.new("ValidateFailed", `Invalid data: {message}`)
 						end
 					end
 
@@ -107,22 +108,22 @@ function Collection:load(key, defaultUserIds)
 				value.lockId ~= nil
 				and (DateTime.now().UnixTimestampMillis - keyInfo.UpdatedTime) / 1000 < LOCK_EXPIRE
 			then
-				return "retry", "Could not acquire lock"
+				return "retry", Error.new("SessionLocked", "Could not acquire lock")
 			end
 
 			local savedVersion = value.migrationVersion
 
 			local migrationOk, migrated, lastCompatibleVersion = Migration.migrate(self.options.migrations, value)
 			if not migrationOk then
-				return "fail", migrated
+				return "fail", Error.new("MigrationError", migrated)
 			end
 
 			if self.options.validate ~= nil then
 				local validateOk, valid, message = pcall(self.options.validate, migrated)
 				if not validateOk then
-					return "fail", `'validate' threw an error: {valid}`
+					return "fail", Error.new("ValidateThrew", `'validate' threw an error: {valid}`)
 				elseif not valid then
-					return "fail", `Invalid data: {message}`
+					return "fail", Error.new("ValidateFailed", `Invalid data: {message}`)
 				end
 			end
 
@@ -162,11 +163,10 @@ function Collection:load(key, defaultUserIds)
 
 			return document
 		end)
-		-- finally is used instead of catch so it doesn't handle rejection.
-		:finally(function(status)
-			if status ~= Promise.Status.Resolved then
-				self.autoSave.ongoingLoads -= 1
-			end
+		:catch(function(err)
+			self.autoSave.ongoingLoads -= 1
+
+			return Promise.reject(`DataStoreFailure({err.message})`)
 		end)
 end
 

--- a/src/Data/Throttle.luau
+++ b/src/Data/Throttle.luau
@@ -1,5 +1,6 @@
 local RunService = game:GetService("RunService")
 
+local Error = require(script.Parent.Parent.Error)
 local Promise = require(script.Parent.Parent.Parent.Promise)
 
 local GET_ASYNC_RETRY_ATTEMPTS = 5
@@ -21,13 +22,13 @@ local function updateAsync(throttle, request)
 					return nil
 				end
 
-				local result, transformed, userIds = request.transform(...)
+				local result, transformed, userIds, metadata = request.transform(...)
 
 				resultOutside = result
 				transformedOutside = transformed
 
 				if result == "succeed" then
-					return transformed, userIds
+					return transformed, userIds, metadata
 				else
 					return nil
 				end
@@ -37,7 +38,7 @@ local function updateAsync(throttle, request)
 		if resultOutside == "cancelled" then
 			resolve("cancelled")
 		elseif not ok then
-			resolve("retry", err)
+			resolve("retry", Error.new("RobloxApiError", err))
 		else
 			resolve(resultOutside, transformedOutside, keyInfo)
 		end
@@ -96,10 +97,10 @@ function Throttle:start()
 		request.attempts -= 1
 
 		if request.attempts == 0 then
-			request.reject(`DataStoreFailure({err})`)
+			request.reject(err)
 		else
 			if self.config:get("showRetryWarnings") then
-				warn(`DataStore operation failed. Retrying...\nError: {err}`)
+				warn(`DataStore operation failed. Retrying...\nError: {err.message}`)
 			end
 
 			task.wait(request.retryDelay)
@@ -136,7 +137,7 @@ function Throttle:start()
 					request.resolve(value, keyInfo)
 				elseif result == "fail" then
 					request.attempts = 0
-					request.reject(`DataStoreFailure({value})`)
+					request.reject(value)
 				elseif result == "retry" then
 					retryRequest(request, value)
 				else

--- a/src/Data/init.luau
+++ b/src/Data/init.luau
@@ -1,3 +1,4 @@
+local Error = require(script.Parent.Error)
 local Promise = require(script.Parent.Parent.Promise)
 local Throttle = require(script.Throttle)
 
@@ -98,6 +99,26 @@ function Data:save(dataStore, key, transform)
 
 		return ongoingSave.pendingSave.promise
 	end
+end
+
+function Data:removeLock(dataStore, key, lockIdToRemove)
+	local function transform(value, keyInfo)
+		if value == nil then
+			return "fail", Error.new("DocumentRemoved", "The document was removed")
+		end
+
+		if value.lockId ~= lockIdToRemove then
+			return "fail", Error.new("SessionLockStolen", "The session lock was stolen")
+		end
+
+		value.lockId = nil
+
+		return "succeed", value, keyInfo:GetUserIds(), keyInfo:GetMetadata()
+	end
+
+	local attempts = self.config:get("saveAttempts")
+
+	return self.throttle:updateAsync(dataStore, key, transform, false, attempts)
 end
 
 function Data:remove(dataStore, key)

--- a/src/Document.luau
+++ b/src/Document.luau
@@ -1,3 +1,4 @@
+local Error = require(script.Parent.Error)
 local freezeDeep = require(script.Parent.freezeDeep)
 local Promise = require(script.Parent.Parent.Promise)
 local noYield = require(script.Parent.noYield)
@@ -15,7 +16,7 @@ local function runCallback(document, name, callback)
 		document.callingCallback = nil
 
 		if not ok then
-			reject(`{name} callback threw error: {message}`)
+			reject(Error.new("BeforeSaveCloseCallbackThrew", `{name} callback threw error: {message}`))
 		else
 			resolve()
 		end
@@ -133,34 +134,38 @@ function Document:save()
 	assert(not self.closed, "Cannot save a closed document")
 	assert(self.callingCallback == nil, `Cannot save in {self.callingCallback} callback`)
 
-	return runCallback(self, "beforeSave", self.beforeSaveCallback):andThen(function()
-		return self.collection.data
-			:save(self.collection.dataStore, self.key, function(value)
-				if value == nil then
-					return "fail", "The document was removed"
-				end
-
-				if value.lockId ~= self.lockId then
-					return "fail", "The session lock was stolen"
-				end
-
-				if not self.collection.options.freezeData and self.validate ~= nil then
-					local validateOk, valid, message = pcall(self.validate, self.data)
-					if not validateOk then
-						return "fail", `'validate' threw an error: {valid}`
-					elseif not valid then
-						return "fail", `Invalid data: {message}`
+	return runCallback(self, "beforeSave", self.beforeSaveCallback)
+		:andThen(function()
+			return self.collection.data
+				:save(self.collection.dataStore, self.key, function(value)
+					if value == nil then
+						return "fail", Error.new("DocumentRemoved", "The document was removed")
 					end
-				end
 
-				value.data = self.data
+					if value.lockId ~= self.lockId then
+						return "fail", Error.new("SessionLockStolen", "The session lock was stolen")
+					end
 
-				return "succeed", value, self.userIds
-			end)
-			:andThen(function(_, keyInfo)
-				self.lastKeyInfo = keyInfo
-			end)
-	end)
+					if not self.collection.options.freezeData and self.validate ~= nil then
+						local validateOk, valid, message = pcall(self.validate, self.data)
+						if not validateOk then
+							return "fail", Error.new("ValidateThrew", `'validate' threw an error: {valid}`)
+						elseif not valid then
+							return "fail", Error.new("ValidateFailed", `Invalid data: {message}`)
+						end
+					end
+
+					value.data = self.data
+
+					return "succeed", value, self.userIds
+				end)
+				:andThen(function(_, keyInfo)
+					self.lastKeyInfo = keyInfo
+				end)
+		end)
+		:catch(function(err)
+			return Promise.reject(`DataStoreFailure({err.message})`)
+		end)
 end
 
 --[=[
@@ -189,19 +194,19 @@ function Document:close()
 			:andThen(function()
 				return self.collection.data:save(self.collection.dataStore, self.key, function(value)
 					if value == nil then
-						return "fail", "The document was removed"
+						return "fail", Error.new("DocumentRemoved", "The document was removed")
 					end
 
 					if value.lockId ~= self.lockId then
-						return "fail", "The session lock was stolen"
+						return "fail", Error.new("SessionLockStolen", "The session lock was stolen")
 					end
 
 					if not self.collection.options.freezeData and self.validate ~= nil then
 						local validateOk, valid, message = pcall(self.validate, self.data)
 						if not validateOk then
-							return "fail", `'validate' threw an error: {valid}`
+							return "fail", Error.new("ValidateThrew", `'validate' threw an error: {valid}`)
 						elseif not valid then
-							return "fail", `Invalid data: {message}`
+							return "fail", Error.new("ValidateFailed", `Invalid data: {message}`)
 						end
 					end
 
@@ -213,6 +218,26 @@ function Document:close()
 			end)
 			:andThen(function(_, keyInfo)
 				self.lastKeyInfo = keyInfo
+			end)
+			:catch(function(err)
+				if
+					err.kind == "BeforeSaveCloseCallbackThrew"
+					or err.kind == "ValidateThrew"
+					or err.kind == "ValidateFailed"
+				then
+					self.collection.autoSave.ongoingRemoveLocks += 1
+
+					self.collection.data
+						:removeLock(self.collection.dataStore, self.key, self.lockId)
+						:catch(function(removeLockErr)
+							warn(`RemoveLockFailure({removeLockErr.message})`)
+						end)
+						:finally(function()
+							self.collection.autoSave.ongoingRemoveLocks -= 1
+						end)
+				end
+
+				return Promise.reject(`DataStoreFailure({err.message})`)
 			end)
 	end
 

--- a/src/Error.luau
+++ b/src/Error.luau
@@ -1,0 +1,21 @@
+type ErrorKind =
+	"RobloxApiError"
+	| "DefaultDataThrew"
+	| "SessionLocked"
+	| "MigrationError"
+	| "BeforeSaveCloseCallbackThrew"
+	| "DocumentRemoved"
+	| "SessionLockStolen"
+	| "ValidateThrew"
+	| "ValidateFailed"
+
+local Error = {}
+
+function Error.new(kind: ErrorKind, message: string)
+	return {
+		kind = kind,
+		message = message,
+	}
+end
+
+return Error

--- a/src/init.test.luau
+++ b/src/init.test.luau
@@ -31,14 +31,14 @@ return function(x)
 		context.lapis = Internal.new(false)
 		context.lapis.setConfig({ dataStoreService = dataStoreService, showRetryWarnings = false })
 
-		context.write = function(name, key, data, lockId)
+		context.write = function(name, key, data, lockId, userIds, metadata)
 			local dataStore = dataStoreService.dataStores[name]["global"]
 
 			dataStore:write(key, {
 				migrationVersion = 0,
 				lockId = lockId,
 				data = data,
-			})
+			}, userIds, metadata)
 		end
 
 		context.read = function(name, key)
@@ -50,6 +50,14 @@ return function(x)
 
 			if data ~= nil and data.lockId ~= nil then
 				error("Document is locked")
+			end
+		end
+
+		context.expectLocked = function(name, key)
+			local data = dataStoreService.dataStores[name]["global"].data[key]
+
+			if data == nil or data.lockId == nil then
+				error("Document is not locked")
 			end
 		end
 
@@ -918,6 +926,194 @@ return function(x)
 			shouldThrow(function()
 				document:close():expect()
 			end, "The document was removed")
+		end)
+	end)
+
+	x.nested("Document:close should still unlock after specific errors", function()
+		x.test("shouldn't overwrite stolen lock", function(context)
+			local collection = context.lapis.createCollection("collection", defaultOptions())
+			local document = collection:load("document"):expect()
+
+			context.write("collection", "document", { apples = 20 }, "stolen lock")
+
+			document:beforeSave(function()
+				error("oh no")
+			end)
+
+			shouldThrow(function()
+				document:close("document"):expect()
+			end)
+
+			task.wait(0.1)
+
+			context.expectLocked("collection", "document")
+		end)
+
+		x.test("doesn't work for session lock stolen error", function(context)
+			local collection = context.lapis.createCollection("collection", defaultOptions())
+			local document = collection:load("document"):expect()
+
+			context.write("collection", "document", { apples = 20 }, "another lock id")
+
+			document:write({ apples = 100 })
+
+			shouldThrow(function()
+				document:close("document"):expect()
+			end)
+
+			task.wait(0.1)
+
+			context.expectLocked("collection", "document")
+			assertEqual(context.read("collection", "document").data.apples, 20) -- Only the lock should have changed.
+		end)
+
+		x.test("beforeSave error", function(context)
+			local collection = context.lapis.createCollection("collection", defaultOptions())
+
+			local document = collection:load("document"):expect()
+
+			document:write({ apples = 100 })
+
+			document:beforeSave(function()
+				error("oh no")
+			end)
+
+			shouldThrow(function()
+				document:close("document"):expect()
+			end)
+
+			task.wait(0.1)
+
+			context.expectUnlocked("collection", "document")
+			assertEqual(context.read("collection", "document").data.apples, 20) -- Only the lock should have changed.
+		end)
+
+		x.test("beforeClose error", function(context)
+			local collection = context.lapis.createCollection("collection", defaultOptions())
+
+			local document = collection:load("document"):expect()
+
+			document:write({ apples = 100 })
+
+			document:beforeClose(function()
+				error("oh no")
+			end)
+
+			shouldThrow(function()
+				document:close("document"):expect()
+			end)
+
+			task.wait(0.1)
+
+			context.expectUnlocked("collection", "document")
+			assertEqual(context.read("collection", "document").data.apples, 20) -- Only the lock should have changed.
+		end)
+
+		x.test("validate error", function(context)
+			local collection = context.lapis.createCollection("collection", {
+				validate = function(data)
+					return typeof(data.apples) == "number", "apples should be a number"
+				end,
+				defaultData = { apples = 20 },
+				freezeData = false,
+			})
+
+			local document = collection:load("document"):expect()
+
+			document:read().apples = nil
+
+			shouldThrow(function()
+				document:close("document"):expect()
+			end)
+
+			task.wait(0.1)
+
+			context.expectUnlocked("collection", "document")
+			assertEqual(context.read("collection", "document").data.apples, 20) -- Only the lock should have changed.
+		end)
+
+		x.test("validate threw error", function(context)
+			local loaded = false
+			local collection = context.lapis.createCollection("collection", {
+				validate = function()
+					if loaded then
+						error("oh no")
+					end
+					return true
+				end,
+				defaultData = { apples = 20 },
+				freezeData = false,
+			})
+
+			local document = collection:load("document"):expect()
+
+			loaded = true
+
+			shouldThrow(function()
+				document:close("document"):expect()
+			end)
+
+			task.wait(0.1)
+
+			context.expectUnlocked("collection", "document")
+			assertEqual(context.read("collection", "document").data.apples, 20) -- Only the lock should have changed.
+		end)
+
+		x.test("onGameClose should wait for the lock to remove", function(context)
+			local collection = context.lapis.createCollection("collection", defaultOptions())
+			local document = collection:load("document"):expect()
+
+			document:beforeSave(function()
+				error("oh no")
+			end)
+
+			context.dataStoreService.yield:startYield()
+
+			shouldThrow(function()
+				document:close("document"):expect()
+			end)
+
+			local thread = task.spawn(function()
+				context.lapis.autoSave:onGameClose()
+			end)
+
+			assert(coroutine.status(thread) == "suspended", "onGameClose didn't wait for locks to be removed")
+
+			context.dataStoreService.yield:stopYield()
+
+			-- Wait for locks to be removed.
+			task.wait(0.1)
+
+			assert(coroutine.status(thread) == "dead", "")
+		end)
+
+		x.testFOCUS("should preserve userids/metadata", function(context)
+			local collection = context.lapis.createCollection("collection", defaultOptions())
+			local document = collection:load("document"):expect()
+
+			document:beforeSave(function()
+				error("oh no")
+			end)
+
+			context.write(
+				"collection",
+				"document",
+				document:read(),
+				context.read("collection", "document").lockId,
+				{ 1234 },
+				{ foo = "bar" }
+			)
+
+			shouldThrow(function()
+				document:close("document"):expect()
+			end)
+
+			task.wait(0.1)
+
+			local keyInfo = context.getKeyInfo("collection", "document")
+
+			assertEqual(keyInfo:GetUserIds()[1], 1234)
+			assertEqual(keyInfo:GetMetadata().foo, "bar")
 		end)
 	end)
 end


### PR DESCRIPTION
The lock will be removed if `Document:close` fails for the following reasons:
* `beforeSave`/`beforeClose` threw an error.
* `validate` threw an error.
* `validate` didn't return `true`.

The lock is only removed if the lock still matches the one the `Document` has. `game:BindToClose` waits for these removals to finish.